### PR TITLE
#38: Feat: Changed from alert to PrimeNG message for the error Band name cannot be empty.

### DIFF
--- a/src/app/band/component/new-band-form/new-band-form.component.ts
+++ b/src/app/band/component/new-band-form/new-band-form.component.ts
@@ -25,7 +25,7 @@ export class NewBandFormComponent {
 
   onSave() {
     if(this.name == '') {
-      alert('Band name cannot be empty.');
+      this.messageService.add({ severity: 'error', summary: 'error', detail: 'Band name cannot be empty.', life: 3000});
       return;
       }
 


### PR DESCRIPTION
Implementation of #38. Should be only one that had to be changed over. A future issue to be added for confirmation of deleting a band in the similar format.