### PR TITLE
Feature 94

### DIFF
--- a/src/app/song/component/song-form/song-form.component.ts
+++ b/src/app/song/component/song-form/song-form.component.ts
@@ -45,9 +45,10 @@ export class SongFormComponent {
       this.songService.fetchSong(this.id).subscribe(res => {
         this.song = res;
         this.name = this.song.name;
-        this.selectedBand = this.song.band;
         this.year = this.song.year;
         this.linkWikiPage = this.song.wikiLinkPage;
+
+        this.selectedBand = this.bands.find(b => b.id === this.song.band.id);
       })
     }
   }


### PR DESCRIPTION
Implementation of #94. Relatively simple fix related to the fact p-select doesn't accept object reference from outside the assigned bands list. Using the band id from the song to search that list to assign the band solves the problem.